### PR TITLE
make snapshot-appending depend only on `snapshot` setting

### DIFF
--- a/base/src/main/scala/org/hammerlab/sbt/plugin/HammerLab.scala
+++ b/base/src/main/scala/org/hammerlab/sbt/plugin/HammerLab.scala
@@ -85,7 +85,7 @@ object HammerLab
           )
         ),
 
-      testUtilsVersion := "1.0.0".snapshot,
+      testUtilsVersion := "1.0.0",
       addTestLib := true
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ default(
   v"4.3.0"
 )
 
-// external plugin short-hands
+// external-plugin short-hands
 val    sbtAssembly = addSbtPlugin("com.eed3si9n"    % "sbt-assembly"        % "0.14.6")
 val       sonatype = addSbtPlugin("org.xerial.sbt"  % "sbt-sonatype"        % "2.0")
 val      scoverage = addSbtPlugin("org.scoverage"   % "sbt-scoverage"       % "1.5.1")

--- a/parent/src/sbt-test/parent/syntax/build.sbt
+++ b/parent/src/sbt-test/parent/syntax/build.sbt
@@ -1,6 +1,4 @@
 
-import com.typesafe.sbt.pgp.PgpKeys._
-
 build(
   v"4.5.6",
   snapshot := true
@@ -10,11 +8,10 @@ lazy val p1 = project.settings(
   v"1.2.3",
   snapshot := false,
   TaskKey[Unit]("check") := {
-    assert(version.value == "1.2.3-SNAPSHOT")
-    assert((version in publishSigned).value == "1.2.3")
-
-    assert(isSnapshot.value)
-    assert(!(isSnapshot in publishSigned).value)
+    assert(version.value == "1.2.3")
+    assert(projectID.value.revision == "1.2.3", projectID.value.revision)
+    assert(makePom.value.getName == "p1_2.12-1.2.3.pom", makePom.value.getName)
+    assert(!isSnapshot.value)
     ()
   }
 )
@@ -23,10 +20,9 @@ lazy val p2 = project.settings(
   v"1.2.3",
   TaskKey[Unit]("check") := {
     assert(version.value == "1.2.3-SNAPSHOT")
-    assert((version in publishSigned).value == "1.2.3-SNAPSHOT")
-
+    assert(projectID.value.revision == "1.2.3-SNAPSHOT", projectID.value.revision)
+    assert(makePom.value.getName == "p2_2.12-1.2.3-SNAPSHOT.pom", makePom.value.getName)
     assert(isSnapshot.value)
-    assert((isSnapshot in publishSigned).value)
     ()
   }
 )
@@ -34,11 +30,10 @@ lazy val p2 = project.settings(
 lazy val p3 = project.settings(
   snapshot := false,
   TaskKey[Unit]("check") := {
-    assert(version.value == "4.5.6-SNAPSHOT")
-    assert((version in publishSigned).value == "4.5.6")
-
-    assert(isSnapshot.value)
-    assert(!(isSnapshot in publishSigned).value)
+    assert(version.value == "4.5.6")
+    assert(projectID.value.revision == "4.5.6", projectID.value.revision)
+    assert(makePom.value.getName == "p3_2.12-4.5.6.pom", makePom.value.getName)
+    assert(!isSnapshot.value)
     ()
   }
 )
@@ -46,10 +41,9 @@ lazy val p3 = project.settings(
 lazy val p4 = project.settings(
   TaskKey[Unit]("check") := {
     assert(version.value == "4.5.6-SNAPSHOT")
-    assert((version in publishSigned).value == "4.5.6-SNAPSHOT")
-
+    assert(projectID.value.revision == "4.5.6-SNAPSHOT", projectID.value.revision)
+    assert(makePom.value.getName == "p4_2.12-4.5.6-SNAPSHOT.pom", makePom.value.getName)
     assert(isSnapshot.value)
-    assert((isSnapshot in publishSigned).value)
     ()
   }
 )

--- a/versions/README.md
+++ b/versions/README.md
@@ -13,13 +13,12 @@ SBT plugin for setting and managing dependencies' versions.
 Set the current project's version with a variety of short-hands:
 
 ```scala
-// Set the version to 1.2.3-SNAPSHOT, except during sbt-pgp's `publishSigned` task, where it will be "1.2.3"
+// Set the version to "1.2.3-SNAPSHOT", or "1.2.3" if "snapshot" is true
 v"1.2.3"
 v("1.2.3")
 
-// when this is true, the above will be a -SNAPSHOT even inside `publishSigned` (e.g. for publishing signed artifacts to 
-// Sonatype snapshots repo)
-snapshot := true
+// un-snapshot the versions set above
+snapshot := false
 ```
 
 These work by setting the `revision` key, which then propagates to the `version` key.

--- a/versions/src/main/scala/org/hammerlab/sbt/plugin/Versions.scala
+++ b/versions/src/main/scala/org/hammerlab/sbt/plugin/Versions.scala
@@ -1,13 +1,17 @@
 package org.hammerlab.sbt.plugin
 
-import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 import org.hammerlab.sbt.deps.VersionOps._
 import org.hammerlab.sbt.deps.{ Dep, GroupArtifact, Snapshot, VersionsMap }
+import sbt.Defaults.artifactPathSetting
 import sbt.Keys._
 import sbt._
+import sbt.plugins.{ IvyPlugin, JvmPlugin }
 
 object Versions
-  extends Plugin {
+  extends Plugin(
+    JvmPlugin,
+    IvyPlugin
+  ) {
 
   implicit val versionsMap = settingKey[VersionsMap]("Map from 'group:artifact' aliases/literals to versions numbers")
 
@@ -22,7 +26,7 @@ object Versions
 
   object autoImport {
     val defaultVersions = settingKey[Seq[DefaultVersion]]("Appendable list of mappings from {group,artifact}s to default-version strings")
-    val snapshot = settingKey[Boolean]("When true, ensure that 'version' ends with '-SNAPSHOT' and snapshots repository is used")
+    val snapshot = settingKey[Boolean]("When true, versions set via `v\"x.y.z\"` shorthands will have '-SNAPSHOT' appended, and snapshots repository will be used")
 
     /**
      * Disable common publishing-related tasks
@@ -44,7 +48,6 @@ object Versions
       Seq(
         version := v
       ) ++
-      inTask(publishSigned)(Seq(version := v)) ++
       noPublish
 
     /**
@@ -61,7 +64,7 @@ object Versions
      */
     implicit def versionsAlias(v: versions.type): defaultVersions.type = defaultVersions
 
-    val revision = settingKey[Option[String]]("Implementation of `version` setting that automatically appends '-SNAPSHOT', except in `publishSigned` if `snapshot` is false")
+    val revision = settingKey[Option[String]]("Implementation of `version` setting that automatically appends '-SNAPSHOT', unless `snapshot` is false")
 
     /**
      * Minimal syntax for setting [[revision]]
@@ -74,7 +77,7 @@ object Versions
      * More syntax for setting [[revision]] / [[version]]:
      *
      * {{{
-     * v"1.0.0"  /** "1.0.0-SNAPSHOT" (set via [[revision]]), but in [[publishSigned]] will lose the "-SNAPSHOT" suffix iff [[snapshot]] is false) */
+     * v"1.0.0"  /** "1.0.0-SNAPSHOT" (set [[version]] via [[revision]]), but "-SNAPSHOT" suffix will depend on the [[snapshot]] setting) */
      * r"1.0.0"  /** Pin to "1.0.0" (set on [[version]] directly), disable publishing */
      * }}}
      */
@@ -90,36 +93,35 @@ object Versions
     Seq(
       defaultVersions := Nil,
       revision := None,
-      snapshot := false
+      snapshot := true
     )
 
   override def projectSettings =
-    inTask(publishSigned)(
-      Seq(
-        /**
-         * In [[com.typesafe.sbt.pgp.PgpKeys.publishSigned publishSigned]], turn [[revision]] (if present) directly into
-         * [[version]] without appending "-SNAPSHOT"
-         */
-        version :=
-          revision
-            .value
-            .map {
-              _.maybeForceSnapshot(snapshot.value)
-            }
-            .getOrElse(version.value),
+    Seq(
+      /**
+       * Turn [[revision]] (if present) directly into [[version]] appending "-SNAPSHOT" or not based on [[snapshot]]
+       */
+      version :=
+        revision
+          .value
+          .map {
+            _.maybeForceSnapshot(snapshot.value)
+          }
+          .getOrElse(version.value),
 
-        /**
-         * Re-iterate this definition of [[isSnapshot]] to reference [[version]] in [[com.typesafe.sbt.pgp.PgpKeys.publishSigned]]
-         */
-        isSnapshot := version.value.endsWith(Snapshot.suffix)
-      )
+      projectID := projectID.value.withRevision(revision = version.value),
+      artifactPath := artifactPathSetting(artifact).value,
+
+      /**
+       * Re-iterate this definition of [[isSnapshot]] to reference [[version]] after it is overwritten by [[revision]]
+       */
+      isSnapshot := version.value.endsWith(Snapshot.suffix)
     ) ++
     Seq(
       /**
        * In general, append "-SNAPSHOT" when turning [[revision]] (which can be set with helpful syntaxes defined in
        * this plugin) into [[version]] (used by main/downstream SBT machinery)
        */
-      version := revision.value.map(_.snapshot).getOrElse(version.value),
 
       versionsMap :=
         VersionsMap(


### PR DESCRIPTION
it used to always append `-SNAPSHOT` except in `publishSigned`, but some settings (e.g. `projectID`) didn't get re-evaluated when `version` was changed that way