### PR TITLE
fork by default, work around scala-js no-fork req

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ default(
   group("org.hammerlab.sbt"),
   clearTestDeps,
   sbtPlugin := true,
-  v"4.4.0"
+  v"4.4.1"
 )
 
 // external-plugin short-hands
@@ -47,7 +47,7 @@ lazy val deps = project.settings(
 lazy val github = project.settings(r"4.1.0")
 
 lazy val js = project.settings(
-  v"1.1.0",
+  v"1.1.1",
   sbtScalaJS,
   scalaJSBundler
 ).dependsOn(

--- a/js/src/main/scala/org/hammerlab/sbt/plugin/JS.scala
+++ b/js/src/main/scala/org/hammerlab/sbt/plugin/JS.scala
@@ -1,16 +1,15 @@
 package org.hammerlab.sbt.plugin
 
-import org.hammerlab.sbt.deps.Group._
+import org.hammerlab.sbt.plugin.Deps.autoImport._
+import org.hammerlab.sbt.plugin.Versions.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import org.scalajs.sbtplugin.cross._
+import sbt.Keys._
 import sbt._
-import Deps.autoImport.deps
-import org.hammerlab.sbt.plugin.Versions.autoImport.defaultVersions
-import org.scalajs.sbtplugin.cross.{ CrossClasspathDependency, CrossProject }
-import sbt.Keys.libraryDependencies
 
 import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin
-import ScalaJSBundlerPlugin.autoImport.npmDependencies
+import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport.npmDependencies
 
 object JS
   extends Plugin(

--- a/js/src/main/scala/org/hammerlab/sbt/plugin/JSFork.scala
+++ b/js/src/main/scala/org/hammerlab/sbt/plugin/JSFork.scala
@@ -1,0 +1,40 @@
+package org.hammerlab.sbt.plugin
+
+import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport.isScalaJSProject
+import sbt.Keys.fork
+import sbt.plugins.JvmPlugin
+import sbt.settingKey
+
+/**
+ * Set [[sbt.Keys.fork]] to `true` by default, but work-around a ScalaJS requirement that it always be set to `false`
+ *
+ * This plugin always triggers, and does not depend on [[org.scalajs.sbtplugin.ScalaJSPlugin]], but references its
+ * [[isScalaJSProject]] settings, which seems generally dicey but seems to work!
+ */
+object JSFork
+  extends Plugin(
+    JvmPlugin
+  ) {
+  object autoImport {
+    val forkJVM = settingKey[Boolean]("Wrapper for `fork`, which scala-js requires to always be set to `false`")
+  }
+  import autoImport._
+  override def globalSettings =
+    Seq(
+      forkJVM := true
+    )
+
+  override def projectSettings =
+    Seq(
+      /*
+       * [[fork]] must be [[false]] in ScalaJS projects, even though they always fork!
+       * cf. https://github.com/scala-js/scala-js/issues/1590#issuecomment-370243830
+       */
+      fork := (
+        if (isScalaJSProject.value)
+          false
+        else
+          forkJVM.value
+        )
+    )
+}

--- a/js/src/sbt-test/js/fork/build.sbt
+++ b/js/src/sbt-test/js/fork/build.sbt
@@ -1,0 +1,44 @@
+
+lazy val a = crossProject.jvmSettings(
+  TaskKey[Unit]("check") := {
+    assert(fork.value == true)
+    ()
+  }
+).jsSettings(
+  TaskKey[Unit]("check") := {
+    assert(fork.value == false)
+    ()
+  }
+)
+lazy val aJS = a.js
+lazy val aJVM = a.jvm
+
+lazy val b = crossProject.jvmSettings(
+  forkJVM := false,
+  TaskKey[Unit]("check") := {
+    assert(fork.value == false)
+    ()
+  }
+).jsSettings(
+  TaskKey[Unit]("check") := {
+    assert(fork.value == false)
+    ()
+  }
+)
+lazy val bJS = b.js
+lazy val bJVM = b.jvm
+
+lazy val c = project.settings(
+  TaskKey[Unit]("check") := {
+    assert(fork.value == true)
+    ()
+  }
+)
+
+lazy val d = project.settings(
+  forkJVM := false,
+  TaskKey[Unit]("check") := {
+    assert(fork.value == false)
+    ()
+  }
+)

--- a/js/src/sbt-test/js/fork/project/plugins.sbt
+++ b/js/src/sbt-test/js/fork/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("org.hammerlab.sbt" % "js" % v)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/js/src/sbt-test/js/fork/test
+++ b/js/src/sbt-test/js/fork/test
@@ -1,0 +1,6 @@
+> aJVM/check
+> aJS/check
+> bJVM/check
+> bJS/check
+> c/check
+> d/check

--- a/versions/src/main/scala/org/hammerlab/sbt/plugin/Versions.scala
+++ b/versions/src/main/scala/org/hammerlab/sbt/plugin/Versions.scala
@@ -5,6 +5,7 @@ import org.hammerlab.sbt.deps.{ Dep, GroupArtifact, Snapshot, VersionsMap }
 import sbt.Defaults.artifactPathSetting
 import sbt.Keys._
 import sbt._
+import Command.command
 import sbt.plugins.{ IvyPlugin, JvmPlugin }
 
 import scala.collection.mutable.ArrayBuffer
@@ -44,6 +45,20 @@ object Versions
   object autoImport {
     val defaultVersions = settingKey[Seq[DefaultVersion]]("Appendable list of mappings from {group,artifact}s to default-version strings")
     val snapshot = settingKey[Boolean]("When true, versions set via `v\"x.y.z\"` shorthands will have '-SNAPSHOT' appended, and snapshots repository will be used")
+
+    val unsnap =
+      command("unsnap") {
+        s ⇒
+          val e = Project.extract(s)
+          e.append(Seq(snapshot := false), s)
+      }
+
+    val unsnapAll =
+      command("unsnapAll") {
+        s ⇒
+          val e = Project.extract(s)
+          e.append(Seq(snapshot in ThisBuild := false), s)
+      }
 
     /*
      * Set the version and disable publishing, for e.g. when a module in a project has not changed and is to remain
@@ -104,6 +119,10 @@ object Versions
 
   override def projectSettings =
     Seq(
+
+      commands += unsnap,
+      commands += unsnapAll,
+
       /**
        * Turn [[revision]] (if present) directly into [[version]] appending "-SNAPSHOT" or not based on [[snapshot]]
        */


### PR DESCRIPTION
also add `unsnap{,All}` commands to `set snapshot := false` for releasing ease